### PR TITLE
Update css-url-rewriter.js

### DIFF
--- a/lib/css-url-rewriter.js
+++ b/lib/css-url-rewriter.js
@@ -12,7 +12,7 @@ var extend = require('extend');
 // Regex to find CSS properties that contain URLs
 // Fiddle: http://refiddle.com/refiddles/css-url-matcher
 // Railroad: http://goo.gl/LXpk52
-var cssPropertyMatcher = /@import[^;]*|[;\s]?\*?[a-zA-Z\-]+\s*\:\#?[\s\S]*url\(\s*['"]?[^'"\)\s]+['"]?\s*\)[^;}]*/g;
+var cssPropertyMatcher = /@import[^;]*|[;\s{]?\*?[a-zA-Z\-]+\s*\:\#?[\s\S]*url\(\s*['"]?[^'"\)\s]+['"]?\s*\)[^;}]*/g;
 
 // Regex to find the URLs within a CSS property value
 // Fiddle: http://refiddle.com/refiddles/match-multiple-urls-within-a-css-property-value


### PR DESCRIPTION
Added { to the regular expression as expressions like this one: .test {background-image:url(_____)}
will not be replaced
